### PR TITLE
feat(teams): team models & migrations

### DIFF
--- a/migrations/2021-08-28-150018_create_teams/down.sql
+++ b/migrations/2021-08-28-150018_create_teams/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE teams

--- a/migrations/2021-08-28-150018_create_teams/up.sql
+++ b/migrations/2021-08-28-150018_create_teams/up.sql
@@ -1,0 +1,8 @@
+-- Your SQL goes here
+CREATE TABLE teams (
+    id SERIAL PRIMARY KEY,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    name TEXT NOT NULL,
+    avatar TEXT,
+    personal BOOLEAN NOT NULL DEFAULT FALSE
+)

--- a/migrations/2021-08-28-153817_create_team_users/down.sql
+++ b/migrations/2021-08-28-153817_create_team_users/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE team_users

--- a/migrations/2021-08-28-153817_create_team_users/up.sql
+++ b/migrations/2021-08-28-153817_create_team_users/up.sql
@@ -1,0 +1,6 @@
+-- Your SQL goes here
+CREATE TABLE team_users (
+    user_id INTEGER NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    team_id INTEGER NOT NULL REFERENCES teams (id) ON DELETE CASCADE,
+    PRIMARY KEY (team_id, user_id)
+)

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,2 +1,4 @@
+pub mod team;
+pub mod team_user;
 pub mod token;
 pub mod user;

--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -1,0 +1,21 @@
+use crate::schema::teams;
+use chrono::NaiveDateTime;
+use serde::Serialize;
+
+#[derive(Debug, Queryable, Serialize, Identifiable)]
+pub struct Team {
+    pub id: i32,
+    #[serde(skip_serializing)]
+    pub created_at: NaiveDateTime,
+    pub name: String,
+    pub avatar: Option<String>,
+    pub personal: bool,
+}
+
+#[derive(Debug, Insertable)]
+#[table_name = "teams"]
+pub struct NewTeam {
+    pub name: String,
+    pub avatar: Option<String>,
+    pub personal: bool,
+}

--- a/src/models/team_user.rs
+++ b/src/models/team_user.rs
@@ -1,0 +1,20 @@
+use serde::Serialize;
+
+use super::{team::Team, user::User};
+use crate::schema::team_users;
+
+#[derive(Debug, Queryable, Serialize, Identifiable, Associations)]
+#[belongs_to(Team)]
+#[belongs_to(User)]
+#[primary_key(team_id, user_id)]
+pub struct TeamUser {
+    pub user_id: i32,
+    pub team_id: i32,
+}
+
+#[derive(Debug, Insertable)]
+#[table_name = "team_users"]
+pub struct NewTeam {
+    pub user_id: i32,
+    pub team_id: i32,
+}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,4 +1,21 @@
 table! {
+    team_users (team_id, user_id) {
+        user_id -> Int4,
+        team_id -> Int4,
+    }
+}
+
+table! {
+    teams (id) {
+        id -> Int4,
+        created_at -> Timestamp,
+        name -> Text,
+        avatar -> Nullable<Text>,
+        personal -> Bool,
+    }
+}
+
+table! {
     tokens (token) {
         token -> Text,
         created_at -> Timestamp,
@@ -17,6 +34,8 @@ table! {
     }
 }
 
+joinable!(team_users -> teams (team_id));
+joinable!(team_users -> users (user_id));
 joinable!(tokens -> users (user_id));
 
-allow_tables_to_appear_in_same_query!(tokens, users,);
+allow_tables_to_appear_in_same_query!(team_users, teams, tokens, users,);


### PR DESCRIPTION
Adds initial team models as well as associating them with users.
Draws inspiration heavily from https://github.com/ChristophWurst/diesel_many_to_many