### PR TITLE
feat(teams): Add team slugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,12 +320,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "futures"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,8 +471,7 @@ dependencies = [
  "dotenv",
  "hex",
  "lazy_static",
- "names",
- "rand 0.8.4",
+ "rand",
  "regex",
  "reqwest",
  "rocket",
@@ -743,15 +736,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "names"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef320dab323286b50fb5cdda23f61c796a72a89998ab565ca32525c5c556f2da"
-dependencies = [
- "rand 0.3.23",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,36 +982,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
-dependencies = [
- "libc",
- "rand 0.4.6",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.3",
+ "rand_core",
  "rand_hc",
 ]
 
@@ -1038,23 +999,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1071,16 +1017,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -1195,7 +1132,7 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
- "rand 0.8.4",
+ "rand",
  "ref-cast",
  "rocket_codegen",
  "rocket_http",
@@ -1578,7 +1515,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if",
  "libc",
- "rand 0.8.4",
+ "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +320,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "futures"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,7 +476,10 @@ dependencies = [
  "diesel",
  "dotenv",
  "hex",
- "rand",
+ "lazy_static",
+ "names",
+ "rand 0.8.4",
+ "regex",
  "reqwest",
  "rocket",
  "rocket_sync_db_pools",
@@ -725,6 +743,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "names"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef320dab323286b50fb5cdda23f61c796a72a89998ab565ca32525c5c556f2da"
+dependencies = [
+ "rand 0.3.23",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,13 +998,36 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
+dependencies = [
+ "libc",
+ "rand 0.4.6",
+]
+
+[[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.3",
  "rand_hc",
 ]
 
@@ -988,8 +1038,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1006,7 +1071,16 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1037,6 +1111,23 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -1104,7 +1195,7 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
- "rand",
+ "rand 0.8.4",
  "ref-cast",
  "rocket_codegen",
  "rocket_http",
@@ -1487,7 +1578,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if",
  "libc",
- "rand",
+ "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,10 @@ chrono = {version = "0.4.19", features = ["serde"]}
 diesel = {version = "1.4.7", features = ["postgres", "chrono"]}
 dotenv = "0.15.0"
 hex = "0.4.3"
+lazy_static = "1.4.0"
+names = "0.11.0"
 rand = "0.8.4"
+regex = "1.5.4"
 reqwest = {version = "0.11.4", features = ["json"]}
 time = "0.2.25"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ diesel = {version = "1.4.7", features = ["postgres", "chrono"]}
 dotenv = "0.15.0"
 hex = "0.4.3"
 lazy_static = "1.4.0"
-names = "0.11.0"
 rand = "0.8.4"
 regex = "1.5.4"
 reqwest = {version = "0.11.4", features = ["json"]}

--- a/migrations/2021-09-01-025208_team_slug/down.sql
+++ b/migrations/2021-09-01-025208_team_slug/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE teams DROP COLUMN slug,
+    ALTER COLUMN name
+SET NOT NULL

--- a/migrations/2021-09-01-025208_team_slug/up.sql
+++ b/migrations/2021-09-01-025208_team_slug/up.sql
@@ -1,0 +1,4 @@
+-- Your SQL goes here
+ALTER TABLE teams
+ADD COLUMN slug TEXT NOT NULL UNIQUE,
+    ALTER COLUMN name DROP NOT NULL

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -43,13 +43,16 @@ paths:
                 example:
                   - id: 1
                     name: Zach Latta's team
+                    slug: wahoo-fish
                     personal: true
                   - id: 8
                     name: Hack as a Service
+                    slug: hack-as-a-service
                     avatar: https://doggo.ninja/dzippy.png
                     personal: false
                   - id: 5
                     name: Hack Club HQ
+                    slug: hackclub
                     avatar: https://assets.hackclub.com/icon-progress-square.svg
                     personal: false
         "500":
@@ -66,17 +69,11 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                avatar:
-                  type: string
-              required:
-                - name
-              example:
-                name: Hack as a Service
-                avatar: https://doggo.ninja/dzippy.png
+              $ref: "#/components/schemas/Team"
+            example:
+              slug: hack-as-a-service
+              name: Hack as a Service
+              avatar: https://doggo.ninja/dzippy.png
       responses:
         "201":
           description: Created
@@ -123,18 +120,23 @@ components:
       properties:
         id:
           type: integer
+          readOnly: true
         name:
+          type: string
+        slug:
           type: string
         avatar:
           type: string
         personal:
           type: boolean
+          readOnly: true
       required:
         - id
-        - name
+        - slug
         - personal
       example:
         id: 8
         name: Hack as a Service
+        slug: hack-as-a-service
         avatar: https://doggo.ninja/dzippy.png
         personal: false

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -1,7 +1,6 @@
 use std::env;
 
 use diesel::prelude::*;
-use names::Generator;
 use rocket::{
     http::{Cookie, CookieJar, SameSite, Status},
     response::Redirect,
@@ -11,7 +10,7 @@ use time::Duration;
 
 use crate::{
     models::{
-        team::{NewTeam, Team},
+        team::{into_slug, NewTeam, Team},
         team_user::TeamUser,
         token::{generate_token, NewToken, Token},
         user::{NewUser, User},
@@ -90,7 +89,7 @@ pub async fn code(conn: DbConn, code: &str, cookies: &CookieJar<'_>) -> Result<R
                     let team = diesel::insert_into(teams)
                         .values(&NewTeam {
                             name: Some(format!("{}'s team", info.name)),
-                            slug: Generator::default().next().unwrap(),
+                            slug: into_slug(&info.name, true),
                             avatar: None,
                             personal: true,
                         })

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -1,6 +1,7 @@
 use std::env;
 
 use diesel::prelude::*;
+use names::Generator;
 use rocket::{
     http::{Cookie, CookieJar, SameSite, Status},
     response::Redirect,
@@ -88,7 +89,8 @@ pub async fn code(conn: DbConn, code: &str, cookies: &CookieJar<'_>) -> Result<R
                     // Create the user's personal team
                     let team = diesel::insert_into(teams)
                         .values(&NewTeam {
-                            name: format!("{}'s team", info.name),
+                            name: Some(format!("{}'s team", info.name)),
+                            slug: Generator::default().next().unwrap(),
                             avatar: None,
                             personal: true,
                         })

--- a/src/api/teams.rs
+++ b/src/api/teams.rs
@@ -3,7 +3,7 @@ use rocket::{http::Status, serde::json::Json};
 
 use crate::{
     models::{
-        team::{NewTeam, Team},
+        team::{validate_slug, NewTeam, Team},
         team_user::TeamUser,
         user::User,
     },
@@ -12,6 +12,10 @@ use crate::{
 
 #[post("/teams", data = "<team>")]
 pub async fn create(user: User, team: Json<NewTeam>, conn: DbConn) -> Result<Json<Team>, Status> {
+    if !validate_slug(&team.slug) {
+        return Err(Status::UnprocessableEntity);
+    }
+
     conn.run(move |c| {
         use crate::schema::team_users::dsl::*;
         use crate::schema::teams::dsl::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,9 @@ extern crate diesel;
 #[macro_use]
 extern crate rocket;
 
+#[macro_use]
+extern crate lazy_static;
+
 use diesel::prelude::*;
 use dotenv::dotenv;
 use rocket::fs::NamedFile;

--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -3,6 +3,8 @@ use chrono::NaiveDateTime;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
+use rand::prelude::*;
+
 lazy_static! {
     static ref SLUG_REGEX: Regex = Regex::new("^[a-z0-9\\-]+$").unwrap();
 }
@@ -30,4 +32,23 @@ pub struct NewTeam {
 
 pub fn validate_slug(slug: &str) -> bool {
     SLUG_REGEX.is_match(slug)
+}
+
+/// Converts any string to a team-compatible slug
+pub fn into_slug(text: &str, randomize: bool) -> String {
+    lazy_static! {
+        static ref INVALID_REGEX: Regex = Regex::new("[^a-z0-9 ]").unwrap();
+    }
+
+    let slug = INVALID_REGEX
+        .replace_all(&text.to_lowercase(), "")
+        .replace(" ", "-");
+
+    if randomize {
+        let mut rng = thread_rng();
+
+        format!("{}-{:4}", slug, rng.gen_range(0..10000))
+    } else {
+        slug
+    }
 }

--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -41,7 +41,7 @@ pub fn into_slug(text: &str, randomize: bool) -> String {
     }
 
     let slug = INVALID_REGEX
-        .replace_all(&text.to_lowercase(), "")
+        .replace_all(&text.trim().to_lowercase(), "")
         .replace(" ", "-");
 
     if randomize {

--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -37,12 +37,12 @@ pub fn validate_slug(slug: &str) -> bool {
 /// Converts any string to a team-compatible slug
 pub fn into_slug(text: &str, randomize: bool) -> String {
     lazy_static! {
-        static ref INVALID_REGEX: Regex = Regex::new("[^a-z0-9 ]").unwrap();
+        static ref INVALID_REGEX: Regex = Regex::new("[^a-z0-9\\-]").unwrap();
     }
 
     let slug = INVALID_REGEX
-        .replace_all(&text.trim().to_lowercase(), "")
-        .replace(" ", "-");
+        .replace_all(&text.trim().to_lowercase().replace(" ", "-"), "")
+        .to_string();
 
     if randomize {
         let mut rng = thread_rng();

--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -1,22 +1,33 @@
 use crate::schema::teams;
 use chrono::NaiveDateTime;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
+
+lazy_static! {
+    static ref SLUG_REGEX: Regex = Regex::new("^[a-z0-9\\-]+$").unwrap();
+}
 
 #[derive(Debug, Queryable, Serialize, Identifiable)]
 pub struct Team {
     pub id: i32,
     #[serde(skip_serializing)]
     pub created_at: NaiveDateTime,
-    pub name: String,
+    pub name: Option<String>,
     pub avatar: Option<String>,
     pub personal: bool,
+    pub slug: String,
 }
 
 #[derive(Debug, Insertable, Deserialize)]
 #[table_name = "teams"]
 pub struct NewTeam {
-    pub name: String,
+    pub name: Option<String>,
     pub avatar: Option<String>,
     #[serde(skip_deserializing)]
     pub personal: bool,
+    pub slug: String,
+}
+
+pub fn validate_slug(slug: &str) -> bool {
+    SLUG_REGEX.is_match(slug)
 }

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -4,6 +4,7 @@ use chrono::NaiveDateTime;
 
 #[derive(Debug, Queryable, Identifiable, Associations)]
 #[primary_key(token)]
+#[table_name = "tokens"]
 #[belongs_to(User)]
 pub struct Token {
     pub token: String,

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -4,7 +4,6 @@ use chrono::NaiveDateTime;
 
 #[derive(Debug, Queryable, Identifiable, Associations)]
 #[primary_key(token)]
-#[table_name = "tokens"]
 #[belongs_to(User)]
 pub struct Token {
     pub token: String,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -9,9 +9,10 @@ table! {
     teams (id) {
         id -> Int4,
         created_at -> Timestamp,
-        name -> Text,
+        name -> Nullable<Text>,
         avatar -> Nullable<Text>,
         personal -> Bool,
+        slug -> Text,
     }
 }
 


### PR DESCRIPTION
This PR adds a unique `slug` field to every team.

Things to note:

- `name` is now optional (the UI should treat `slug` as the team's name if `name` is not present)
- `slug` can only contain lowercase letters and hyphens for now
- Auto-created personal teams have a slug based on their username (e.g. `caleb-denio-3977`)
- wahoo