### PR TITLE
minor: Pin Hadolint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: cargo clippy -- -D warnings
   lint-docker:
     runs-on: ubuntu-latest
-    container: hadolint/hadolint:latest-debian
+    container: hadolint/hadolint:v2.8.0-debian
     name: Lint (Dockerfile)
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Latest version doesn't appropriately evaluate instruction orders. Reverting to previous version.

See https://github.com/hadolint/hadolint/issues/795